### PR TITLE
CI update build workflow triggers

### DIFF
--- a/.github/workflows/build-on-commit.yaml
+++ b/.github/workflows/build-on-commit.yaml
@@ -1,9 +1,11 @@
 name: Build on commit
+
 on:
+  pull_request:
   push:
     branches:
-      - master
-      - next-version
+      - main
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update GitHub Actions to trigger builds on pull requests and to use the `main` branch.